### PR TITLE
Vectorize PMF scaling and epsilon scatter; expose similarity precompute for grid sweeps

### DIFF
--- a/semantic_similarity_rating/compute.py
+++ b/semantic_similarity_rating/compute.py
@@ -54,6 +54,158 @@ def scale_pmf(pmf, temperature, max_temp=np.inf):
     return hist / hist.sum()
 
 
+def scale_pmfs(pmfs, temperature, max_temp=np.inf):
+    """
+    Scale a batch of PMFs using temperature scaling (vectorized).
+
+    Parameters
+    ----------
+    pmfs : array_like, shape (n, k)
+        Stack of probability mass functions, one per row.
+    temperature : float
+        Temperature parameter for scaling (0 to max_temp).
+    max_temp : float, optional
+        Maximum temperature value, by default np.inf
+
+    Returns
+    -------
+    numpy.ndarray, shape (n, k)
+        Scaled PMFs where each row sums to 1.
+
+    Notes
+    -----
+    Semantically equivalent to applying ``scale_pmf`` to each row, but
+    implemented with numpy broadcasting to avoid per-row Python overhead.
+    """
+    pmfs = np.asarray(pmfs)
+    if pmfs.ndim == 1:
+        return scale_pmf(pmfs, temperature, max_temp=max_temp)
+
+    if temperature == 0.0:
+        # One-hot at argmax per row; pass-through rows that are uniform.
+        out = np.zeros_like(pmfs)
+        out[np.arange(pmfs.shape[0]), np.argmax(pmfs, axis=1)] = 1.0
+        uniform_rows = np.all(pmfs == pmfs[:, :1], axis=1)
+        out[uniform_rows] = pmfs[uniform_rows]
+        return out
+
+    t = min(temperature, max_temp)
+    hist = pmfs ** (1 / t)
+    return hist / hist.sum(axis=1, keepdims=True)
+
+
+def cosine_similarity_matrix(matrix_responses, matrix_likert_sentences):
+    """
+    Compute the (1 + cosine) / 2 similarity between response and Likert embeddings.
+
+    Parameters
+    ----------
+    matrix_responses : array_like, shape (n_responses, dim)
+        Response embeddings, one per row.
+    matrix_likert_sentences : array_like, shape (dim, n_likert_points)
+        Likert anchor embeddings, one per column.
+
+    Returns
+    -------
+    numpy.ndarray, shape (n_responses, n_likert_points)
+        Similarity matrix in [0, 1]: γ(r, ℓ) = (1 + cosine(r, ℓ)) / 2.
+
+    Notes
+    -----
+    Kept as a separate step so callers sweeping over (temperature, epsilon)
+    grids can precompute similarities once and pass them to
+    ``similarities_to_pmf`` / ``scale_pmfs`` in the inner loop.
+    """
+    M_left = matrix_responses
+    M_right = matrix_likert_sentences
+
+    if M_left.shape[0] == 0:
+        return np.empty((0, M_right.shape[1]))
+
+    norm_right = np.linalg.norm(M_right, axis=0)
+    M_right = M_right / norm_right[None, :]
+
+    norm_left = np.linalg.norm(M_left, axis=1)
+    M_left = M_left / norm_left[:, None]
+
+    return (1 + M_left.dot(M_right)) / 2
+
+
+def precompute_similarity_stats(cos):
+    """
+    Precompute per-row reductions of a cosine similarity matrix.
+
+    Amortizes the row-wise min, sum, and argmin over an outer sweep of
+    ``(temperature, epsilon)`` pairs — each is otherwise recomputed on
+    every call inside ``similarities_to_pmf``.
+
+    Parameters
+    ----------
+    cos : array_like, shape (n_responses, n_likert_points)
+        Output of ``cosine_similarity_matrix``.
+
+    Returns
+    -------
+    dict
+        Keys: ``cos`` (the input), ``cos_min`` (shape (n, 1)),
+        ``cos_sum`` (shape (n, 1)), ``min_indices`` (shape (n,)).
+    """
+    cos = np.asarray(cos)
+    return {
+        "cos": cos,
+        "cos_min": cos.min(axis=1, keepdims=True),
+        "cos_sum": cos.sum(axis=1, keepdims=True),
+        "min_indices": np.argmin(cos, axis=1),
+    }
+
+
+def similarities_to_pmf(similarities, epsilon=0.0):
+    """
+    Apply the SSR numerator/denominator formula to precomputed similarities.
+
+    Parameters
+    ----------
+    similarities : array_like or dict
+        Either a raw similarity matrix (shape ``(n_responses, n_likert_points)``)
+        or a dict produced by ``precompute_similarity_stats``. The dict form
+        avoids recomputing the row-wise min/sum/argmin for every call — useful
+        when sweeping over an ``epsilon`` grid.
+    epsilon : float, optional
+        Regularization added at the minimum-similarity position and to the
+        denominator. Default 0.0.
+
+    Returns
+    -------
+    numpy.ndarray, shape (n_responses, n_likert_points)
+        Per-response PMF over the Likert scale.
+    """
+    if isinstance(similarities, dict):
+        cos = similarities["cos"]
+        cos_min = similarities["cos_min"]
+        cos_sum = similarities["cos_sum"]
+        min_indices = similarities["min_indices"]
+    else:
+        cos = np.asarray(similarities)
+        if cos.shape[0] == 0:
+            return np.empty_like(cos)
+        cos_min = cos.min(axis=1, keepdims=True)
+        cos_sum = cos.sum(axis=1, keepdims=True)
+        min_indices = None  # Computed lazily if epsilon > 0.
+
+    if cos.shape[0] == 0:
+        return np.empty_like(cos)
+
+    numerator = cos - cos_min
+    if epsilon > 0:
+        if min_indices is None:
+            min_indices = np.argmin(cos, axis=1)
+        numerator[np.arange(cos.shape[0]), min_indices] += epsilon
+
+    n_likert_points = cos.shape[1]
+    denominator = cos_sum - n_likert_points * cos_min + epsilon
+    return numerator / denominator
+
+
 def response_embeddings_to_pmf(matrix_responses, matrix_likert_sentences, epsilon=0.0):
     """
     Convert response embeddings and Likert sentence embeddings to a PMF.
@@ -80,43 +232,10 @@ def response_embeddings_to_pmf(matrix_responses, matrix_likert_sentences, epsilo
                  [Σ_r γ(σ_{r,i}, t_c̃) - n_points * γ(σ_ℓ,i, t_c̃) + ε]
     where γ is the cosine similarity function, δ_ℓ,r is the Kronecker delta,
     and n_points is the number of Likert scale points.
+
+    When sweeping (temperature, epsilon), prefer precomputing the cosine
+    matrix with ``cosine_similarity_matrix`` and reusing it via
+    ``similarities_to_pmf`` — this avoids redundant normalization and matmul.
     """
-    M_left = matrix_responses
-    M_right = matrix_likert_sentences
-
-    # Handle empty input case
-    if M_left.shape[0] == 0:
-        return np.empty((0, M_right.shape[1]))
-
-    # Normalize the right matrix (Likert sentences)
-    norm_right = np.linalg.norm(M_right, axis=0)
-    M_right = M_right / norm_right[None, :]
-
-    # Normalize the left matrix (responses)
-    norm_left = np.linalg.norm(M_left, axis=1)
-    M_left = M_left / norm_left[:, None]
-
-    # Calculate cosine similarities: γ(σ_{r,i}, t_c̃)
-    cos = (1 + M_left.dot(M_right)) / 2
-
-    # Find minimum similarity per row: γ(σ_ℓ,i, t_c̃)
-    cos_min = cos.min(axis=1)[:, None]
-
-    # Numerator: γ(σ_{r,i}, t_c̃) - γ(σ_ℓ,i, t_c̃) + ε δ_ℓ,r
-    # The ε δ_ℓ,r term adds epsilon only to exactly one minimum similarity position per row
-    numerator = cos - cos_min
-    if epsilon > 0:
-        # Add epsilon to the first position that achieves minimum in each row (Kronecker delta effect)
-        min_indices = np.argmin(cos, axis=1)
-        for i, min_idx in enumerate(min_indices):
-            numerator[i, min_idx] += epsilon
-
-    # Denominator: Σ_r γ(σ_{r,i}, t_c̃) - n_likert_points * γ(σ_ℓ,i, t_c̃) + ε
-    # This is: sum of all similarities - n_likert_points * minimum similarity + epsilon
-    n_likert_points = cos.shape[1]
-    denominator = cos.sum(axis=1)[:, None] - n_likert_points * cos_min + epsilon
-
-    # Calculate final PMF
-    pmf = numerator / denominator
-
-    return pmf
+    cos = cosine_similarity_matrix(matrix_responses, matrix_likert_sentences)
+    return similarities_to_pmf(cos, epsilon=epsilon)

--- a/semantic_similarity_rating/response_rater.py
+++ b/semantic_similarity_rating/response_rater.py
@@ -259,7 +259,8 @@ class ResponseRater:
             if not isinstance(llm_responses, np.ndarray):
                 raise ValueError(
                     "ResponseRater is in embedding mode (dataframe contains 'embedding' column). "
-                    "Expected numpy array of embeddings, got: " + str(type(llm_responses))
+                    "Expected numpy array of embeddings, got: "
+                    + str(type(llm_responses))
                 )
             llm_response_matrix = llm_responses
         else:

--- a/semantic_similarity_rating/response_rater.py
+++ b/semantic_similarity_rating/response_rater.py
@@ -229,11 +229,89 @@ class ResponseRater:
             )
 
         if temperature != 1.0:
-            llm_response_pmfs = np.array(
-                [compute.scale_pmf(_pmf, temperature) for _pmf in llm_response_pmfs]
-            )
+            llm_response_pmfs = compute.scale_pmfs(llm_response_pmfs, temperature)
 
         return llm_response_pmfs
+
+    def compute_response_similarities(self, llm_responses):
+        """
+        Precompute per-reference-set cosine similarity statistics for responses.
+
+        Use this together with :meth:`pmfs_from_similarities` when sweeping over
+        a grid of ``(temperature, epsilon)`` values — the embedding encoding,
+        normalization, and matmul run once; the inner loop becomes pure
+        elementwise arithmetic on the cached row-wise reductions.
+
+        Parameters
+        ----------
+        llm_responses : list of str or numpy.ndarray
+            Text mode: list of strings. Embedding mode: ``(n_responses, dim)`` array.
+
+        Returns
+        -------
+        dict
+            Maps reference-set id (str) to a stats dict from
+            :func:`compute.precompute_similarity_stats`. Keys in the dict are
+            ``cos`` (``(n, 5)``), ``cos_min`` (``(n, 1)``), ``cos_sum`` (``(n, 1)``),
+            and ``min_indices`` (``(n,)``).
+        """
+        if self.embedding_mode:
+            if not isinstance(llm_responses, np.ndarray):
+                raise ValueError(
+                    "ResponseRater is in embedding mode (dataframe contains 'embedding' column). "
+                    "Expected numpy array of embeddings, got: " + str(type(llm_responses))
+                )
+            llm_response_matrix = llm_responses
+        else:
+            if not isinstance(llm_responses, (list, tuple)):
+                raise ValueError(
+                    "ResponseRater is in text mode (no 'embedding' column in dataframe). "
+                    "Expected list of text strings, got: " + str(type(llm_responses))
+                )
+            llm_response_matrix = self.model.encode(llm_responses)
+
+        stats_by_ref = {}
+        for ref_id, M in self.reference_matrices.items():
+            cos = compute.cosine_similarity_matrix(llm_response_matrix, M)
+            stats_by_ref[ref_id] = compute.precompute_similarity_stats(cos)
+        return stats_by_ref
+
+    def pmfs_from_similarities(
+        self, reference_set_id, similarity_stats, temperature=1.0, epsilon=0.0
+    ):
+        """
+        Map precomputed similarity stats to PMFs — no encoding, no matmul.
+
+        Parameters
+        ----------
+        reference_set_id : str
+            Reference set id, or ``'mean'`` to average PMFs across all sets.
+        similarity_stats : dict
+            Output of :meth:`compute_response_similarities`.
+        temperature : float, default 1.0
+            Temperature for ``scale_pmfs`` (applied if != 1.0).
+        epsilon : float, default 0.0
+            Regularization passed to ``similarities_to_pmf``.
+
+        Returns
+        -------
+        numpy.ndarray, shape (n_responses, n_likert_points)
+        """
+        if isinstance(reference_set_id, str) and reference_set_id.lower() == "mean":
+            pmfs = np.array(
+                [
+                    compute.similarities_to_pmf(stats, epsilon)
+                    for stats in similarity_stats.values()
+                ]
+            ).mean(axis=0)
+        else:
+            pmfs = compute.similarities_to_pmf(
+                similarity_stats[reference_set_id], epsilon
+            )
+
+        if temperature != 1.0:
+            pmfs = compute.scale_pmfs(pmfs, temperature)
+        return pmfs
 
     def get_survey_response_pmf(self, response_pmfs):
         """


### PR DESCRIPTION
## Summary

Performance refactor of the SSR pipeline — no behavior changes to existing APIs, plus new entry points for cheap `(temperature, epsilon)` grid sweeps.

### `compute.py`
- **`scale_pmfs`** (new): batched temperature scaling via numpy broadcasting. Replaces the per-row `scale_pmf` Python loop in `ResponseRater.get_response_pmfs`. Handles the `temperature == 0` one-hot case (incl. uniform-row pass-through) and `max_temp` capping identically to the scalar version.
- **Epsilon scatter vectorized**: the per-row `for i, min_idx in enumerate(min_indices)` loop adding ε at the Kronecker-delta position is now a single fancy-indexed scatter.
- **`response_embeddings_to_pmf` split** into `cosine_similarity_matrix` + `similarities_to_pmf`, so the normalization + matmul can be computed once and reused across parameter sweeps. The original function delegates to both and returns identical results.
- **`precompute_similarity_stats`** (new): caches row-wise min/sum/argmin of the similarity matrix so an epsilon sweep's inner loop is pure elementwise arithmetic.

### `response_rater.py`
- `get_response_pmfs` now uses `scale_pmfs` instead of a list comprehension over `scale_pmf`.
- **`compute_response_similarities`** / **`pmfs_from_similarities`** (new): encode + matmul once, then map cached stats to PMFs for any `(temperature, epsilon)` pair — including the `'mean'` reference-set aggregation.

## Verification
- Full test suite passes (28 passed).
- Numerical equivalence checked between old and new paths:
  - `scale_pmfs` vs row-wise `scale_pmf` for T ∈ {0, 0.3, 1, 7, 100} with `max_temp` capping, including a uniform row
  - `response_embeddings_to_pmf` vs `cosine_similarity_matrix` → `similarities_to_pmf` (raw matrix and precomputed-stats forms) for ε ∈ {0, 1e-3, 0.1}
  - Empty-input shape preserved; repeated calls on cached stats don't mutate the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)